### PR TITLE
Fix backwards compatibility with Python 2:

### DIFF
--- a/addon/globalPlugins/dictionariesAlmaany/fetchtext.py
+++ b/addon/globalPlugins/dictionariesAlmaany/fetchtext.py
@@ -4,7 +4,7 @@
 
 import textInfos
 import sys
-if sys.version_info == 2:
+if sys.version_info.major == 2:
 	import urllib
 	from . import urllib2
 else:
@@ -55,14 +55,14 @@ class MyThread(threading.Thread):
 		self.error= False
 
 	def run(self):
-		text= self.text.encode('utf8') if sys.version_info == 2 else self.text
-		url= self.base_url+ urllib.quote(text) if sys.version_info == 2 else self.base_url + urllib.parse.quote(text)
-		request= urllib2.Request(url) if sys.version_info == 2 else urllib.request.Request(url)
+		text= self.text.encode('utf8') if sys.version_info.major == 2 else self.text
+		url= self.base_url+ urllib.quote(text) if sys.version_info.major == 2 else self.base_url + urllib.parse.quote(text)
+		request= urllib2.Request(url) if sys.version_info.major == 2 else urllib.request.Request(url)
 		request.add_header('User-Agent', random.choice(userAgentList))
 		try:
 			#handle = urllib.urlopen(url)
-			handle = urllib2.urlopen(request) if sys.version_info == 2 else urllib.request.urlopen(request)
-			html= handle.read() if sys.version_info == 2 else handle.read().decode(handle.headers.get_content_charset())
+			handle = urllib2.urlopen(request) if sys.version_info.major == 2 else urllib.request.urlopen(request)
+			html= handle.read() if sys.version_info.major == 2 else handle.read().decode(handle.headers.get_content_charset())
 			handle.close()
 #			log.info(html)
 		except Exception as e:
@@ -81,6 +81,6 @@ class MyThread(threading.Thread):
 				self.error= str(e)
 			else:
 				page= content +"<p> <a href=%s>"%(url) +"Look for the meaning in the browser</a></p>"
-				page= unicode(page, 'utf-8') if sys.version_info == 2 else page
+				page= unicode(page, 'utf-8') if sys.version_info.major == 2 else page
 				#ui.browseableMessage(page, "قاموس المَعَاني", isHtml= True)
 				self.meaning= page

--- a/addon/globalPlugins/dictionariesAlmaany/myDialog.py
+++ b/addon/globalPlugins/dictionariesAlmaany/myDialog.py
@@ -4,6 +4,7 @@
 import wx
 import queueHandler
 import config
+import sys
 from .fetchtext import MyThread
 from .fetchtext import isSelectedText
 from .getbrowsers import getBrowsers
@@ -16,14 +17,16 @@ import ui
 import os
 import addonHandler
 addonHandler.initTranslation()
-
+if sys.version_info.major == 2:
+	import io
+	open = io.open
 #browsers as dictionary with label as key, and executable path as value.
 browsers= getBrowsers()
 
 def appIsRunning(app):
 	'''Checks if specific app is running or not.
 	'''
-	processes= subprocess.check_output('tasklist', shell=True).decode()
+	processes= subprocess.check_output('tasklist', shell=True).decode('mbcs')
 	return app in processes
 
 def openBrowserWindow(label, meaning, directive):
@@ -33,8 +36,8 @@ def openBrowserWindow(label, meaning, directive):
 	<title>{title}</title>
 	<meta name=viewport content='initial-scale=1.0'>
 	""".format(title= _('Dictionaries Almaany')) + meaning 
-	f= tempfile.NamedTemporaryFile(mode= 'w', encoding= 'utf-8', suffix= '.html', delete= False)
-	f.write(html)
+	f= tempfile.NamedTemporaryFile(mode= 'w', encoding= 'utf-8', suffix= '.html', delete= False) if sys.version_info.major > 2 else tempfile.NamedTemporaryFile(mode= 'w', suffix= '.html', delete= False)
+	f.write((html if sys.version_info.major > 2 else html.encode('utf-8')))
 	f.close()
 	path= os.path.join('file:///', f.name)
 	subprocess.Popen(browsers[label] + directive + path)
@@ -99,6 +102,7 @@ class MyDialog(wx.Dialog):
 			beep(500, 100)
 			time.sleep(0.5)
 		t.join()
+
 
 		title= u'المَعَاني message box'
 		useBrowserWindow= config.conf["dictionariesAlmaany"]["windowType"]== 0

--- a/addon/globalPlugins/dictionariesAlmaany/myDialog.py
+++ b/addon/globalPlugins/dictionariesAlmaany/myDialog.py
@@ -42,8 +42,6 @@ def openBrowserWindow(label, meaning, directive):
 	f = open(path, "w", encoding="utf-8")
 	f.write(html)
 	f.close()
-	#webbrowser.open ("file://" + path)
-	path= os.path.join('file:///', f.name)
 	#subprocess.Popen(browsers[label] + directive + path)
 	webbrowser.open(path)
 	t=threading.Timer(30.0, os.remove, [f.name])

--- a/addon/globalPlugins/dictionariesAlmaany/myDialog.py
+++ b/addon/globalPlugins/dictionariesAlmaany/myDialog.py
@@ -5,6 +5,7 @@ import wx
 import queueHandler
 import config
 import sys
+import webbrowser
 from .fetchtext import MyThread
 from .fetchtext import isSelectedText
 from .getbrowsers import getBrowsers
@@ -36,11 +37,15 @@ def openBrowserWindow(label, meaning, directive):
 	<title>{title}</title>
 	<meta name=viewport content='initial-scale=1.0'>
 	""".format(title= _('Dictionaries Almaany')) + meaning 
-	f= tempfile.NamedTemporaryFile(mode= 'w', encoding= 'utf-8', suffix= '.html', delete= False) if sys.version_info.major > 2 else tempfile.NamedTemporaryFile(mode= 'w', suffix= '.html', delete= False)
-	f.write((html if sys.version_info.major > 2 else html.encode('utf-8')))
+	temp= tempfile.NamedTemporaryFile(delete=False)
+	path = temp.name + ".html"
+	f = open(path, "w", encoding="utf-8")
+	f.write(html)
 	f.close()
+	#webbrowser.open ("file://" + path)
 	path= os.path.join('file:///', f.name)
-	subprocess.Popen(browsers[label] + directive + path)
+	#subprocess.Popen(browsers[label] + directive + path)
+	webbrowser.open(path)
 	t=threading.Timer(30.0, os.remove, [f.name])
 	t.start()
 


### PR DESCRIPTION
#### This PR includes the following improvement for backward compatibility with Python 2:

* Changed sys.version_info to sys.version_info.major in "addon/globalPlugins/dictionariesAlmaany/fetchtext.py";
* Fixed lines 39 and 40 in addon/globalPlugins/dictionariesAlmaany/myDialog.py" for backward compatibility with Python 2 and nvda-2019.2.1;
* Used webbrowser instead of subprocess to open pages in the default browser, (subprocess often tends to open them in Internet Explorer although it is not our default browser).
